### PR TITLE
Moved "reading notifications" for current conversation to condition

### DIFF
--- a/app/controllers/ChatController.php
+++ b/app/controllers/ChatController.php
@@ -15,13 +15,13 @@ class ChatController extends \BaseController {
             $current_conversation = Auth::user()->conversations()->first();
         }
 
-        foreach($current_conversation->messages_notifications as $notification) {
-            $notification->read = true;
-            $notification->save();
-        }
-
         if($current_conversation) {
             Session::set('current_conversation', $current_conversation->name);
+    
+            foreach($current_conversation->messages_notifications as $notification) {
+                $notification->read = true;
+                $notification->save();
+            }
         }
 
         $conversations = Auth::user()->conversations()->get();


### PR DESCRIPTION
When user has not any conversations, app throws ErrorException "Trying to get property of non-object".
